### PR TITLE
Rename client -> UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
     - echo $TRAVIS_REPO_SLUG
   
 script:
-    # Lint, build client
+    # Lint, build UI
     - npm install
     - npm run lint
     - npm run build-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
 FROM node:8 as builder
 
-WORKDIR /project/client
+WORKDIR /project/ui
 
-COPY . /client
+COPY . /ui
 
-WORKDIR /client
+WORKDIR /ui
 RUN npm install \
     && npm run build-dev
 
 FROM httpd:2.4-alpine
 
-COPY --from=builder /client /client
+COPY --from=builder /ui /ui
 
 # Remove default index.html
 RUN rm /usr/local/apache2/htdocs/index.html
 
-# Copy client over
-RUN cp -rf /client/public/* /usr/local/apache2/htdocs
+# Copy UI over
+RUN cp -rf /ui/public/* /usr/local/apache2/htdocs
 
 RUN echo -e "\
     \n\

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Client [![Build Status](https://travis-ci.org/target/consensource-ui.svg?branch=master)](https://travis-ci.org/target/consensource-ui)
+# ConsenSource UI [![Build Status](https://travis-ci.org/target/consensource-ui.svg?branch=master)](https://travis-ci.org/target/consensource-ui)
 
 The ConsenSource UI is comprised of a number of Mithril applications under the same router. The default application that is served from the `index.html` page is for retailers. To access the other apps, specify the relative .html file in [/public](/client/public) such as `localhost:8080/index_auditor.html`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "consensource-client",
+  "name": "consensource-ui",
   "version": "0.1.0",
-  "description": "ConsenSource Client",
+  "description": "ConsenSource UI",
   "main": "dist/retailer.js",
   "scripts": {
     "clean": "rm -f src/compiled_protobufs.json public/js/*.js",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/target/ConsenSource"
+    "url": "https://github.com/target/consensource-ui"
   },
   "keywords": [
     "webclient"

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Certification Registry</title>
+    <title>ConsenSource Retailer</title>
     <link rel="stylesheet" href="/css/vendor/bootstrap.min.css">
     <link rel="stylesheet" href="/css/vendor/flat-ui.css">
     <link rel="stylesheet" href="/css/main.css">

--- a/public/index_auditor.html
+++ b/public/index_auditor.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Auditor</title>
+    <title>ConsenSource Auditor</title>
     <link rel="stylesheet" href="/css/vendor/mithril-datepicker.css">
     <link rel="stylesheet" href="/css/vendor/bootstrap.min.css">
     <link rel="stylesheet" href="/css/vendor/flat-ui.css">

--- a/public/index_factory.html
+++ b/public/index_factory.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Factory</title>
+    <title>ConsenSource Factory</title>
     <link rel="stylesheet" href="/css/vendor/bootstrap.min.css">
     <link rel="stylesheet" href="/css/vendor/flat-ui.css">
     <link rel="stylesheet" href="/css/main.css">

--- a/public/index_standards_body.html
+++ b/public/index_standards_body.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Standards Body</title>
+    <title>ConsenSource Standards Body</title>
     <link rel="stylesheet" href="/css/vendor/mithril-datepicker.css">
     <link rel="stylesheet" href="/css/vendor/bootstrap.min.css">
     <link rel="stylesheet" href="/css/vendor/flat-ui.css">


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Depends on https://github.com/target/consensource-compose/pull/3

This PR refactors instances of the phrase `client` with `ui`. This is done to match the updated name of the repo - `ConsenSource UI`.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

In the compose repo:

1. `./docker-helper.sh --build client` 
2. `./docker-helper.sh --run client` and verify it succeeds by visiting `http://localhost:8080/`