### PR TITLE
Add signup feature flag

### DIFF
--- a/.env.feature-flags
+++ b/.env.feature-flags
@@ -2,3 +2,4 @@
 ## or else Webpack will error
 
 ENABLE_TESTING_BANNER=false
+ENABLE_SIGNUP=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "consensource-client",
+  "name": "consensource-ui",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -16,7 +16,8 @@ const getFeatureFlagVal = (val) => {
 }
 
 const featureFlagConfigs = {
-    "enableTestingBanner": getFeatureFlagVal(process.env.ENABLE_TESTING_BANNER)
+    "enableTestingBanner": getFeatureFlagVal(process.env.ENABLE_TESTING_BANNER),
+    "enableSignup": getFeatureFlagVal(process.env.ENABLE_SIGNUP)
 }
 
 module.exports = {

--- a/src/entrypoint_auditor.js
+++ b/src/entrypoint_auditor.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const m = require('mithril')
+const FeatureFlagService = require('App/services/feature_flag')
 
 const { App, Welcome } = require('App/views/auditor')
 const { AgentProfile } = require('App/views/common/profile')
@@ -18,7 +19,7 @@ m.route(element, '/', {
   '/': App.subpage(Welcome),
 
   '/signIn': App.subpage(SignInForm),
-  '/signUp': App.subpage(AgentSignUpForm),
+  '/signUp': App.subpage(FeatureFlagService.isSignupEnabled() && AgentSignUpForm),
   '/profile': App.subpage(AgentProfile),
 
   '/organizationCreate': App.subpage(CreateCertifyingBody),

--- a/src/entrypoint_factory.js
+++ b/src/entrypoint_factory.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const m = require('mithril')
+const FeatureFlagService = require('App/services/feature_flag')
 
 const { SignInForm } = require('App/views/common/auth')
 const { App, Welcome } = require('App/views/factory')
@@ -13,7 +14,7 @@ AuthService.namespace = 'factory'
 let element = document.getElementById("app")
 m.route(element, '/', {
     '/': App.subpage(Welcome),
-    '/signUp': App.subpage(FactorySignUpForm),
+    '/signUp': App.subpage(FeatureFlagService.isSignupEnabled() && FactorySignUpForm),
     '/signIn': App.subpage(SignInForm),
     '/profile': App.subpage(FactoryDetails),
     '/requests': App.subpage(ListCertifications)

--- a/src/entrypoint_standards_body.js
+++ b/src/entrypoint_standards_body.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const m = require('mithril')
+const FeatureFlagService = require('App/services/feature_flag')
 
 const { App, Welcome } = require('App/views/standards_body')
 const { AgentProfile } = require('App/views/common/profile')
@@ -18,7 +19,7 @@ m.route(element, '/', {
   '/': App.subpage(Welcome),
 
   '/signIn': App.subpage(SignInForm),
-  '/signUp': App.subpage(AgentSignUpForm),
+  '/signUp': App.subpage(FeatureFlagService.isSignupEnabled() && AgentSignUpForm),
   '/profile': App.subpage(AgentProfile),
 
   '/organizationCreate': App.subpage(CreateStandardsBody),

--- a/src/services/feature_flag.js
+++ b/src/services/feature_flag.js
@@ -1,7 +1,9 @@
 const { featureFlagConfigs } = require('App/config')
 
 const isTestBannerEnabled = () => featureFlagConfigs.enableTestingBanner
+const isSignupEnabled = () => featureFlagConfigs.enableSignup
 
 module.exports = {
-    isTestBannerEnabled
+    isTestBannerEnabled,
+    isSignupEnabled
 }

--- a/src/views/auditor/index.js
+++ b/src/views/auditor/index.js
@@ -27,7 +27,7 @@ const _authButtons = () => {
   } else {
     return [
       m('a.btn.btn-outline-success[href=/signIn]', { oncreate: m.route.link }, 'Sign In'),
-      m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
+      FeatureFlagService.isSignupEnabled() && m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
     ]
   }
 }

--- a/src/views/factory/index.js
+++ b/src/views/factory/index.js
@@ -29,7 +29,7 @@ const _authButtons = () => {
   } else {
     return [
       m('a.btn.btn-outline-success[href=/signIn]', { oncreate: m.route.link }, 'Sign In'),
-      m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
+      FeatureFlagService.isSignupEnabled() && m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
     ]
   }
 }

--- a/src/views/standards_body/index.js
+++ b/src/views/standards_body/index.js
@@ -26,7 +26,7 @@ const _authButtons = () => {
   } else {
     return [
       m('a.btn.navbar-signin[href=/signIn]', { oncreate: m.route.link }, 'Sign In'),
-      m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
+      FeatureFlagService.isSignupEnabled() && m('a.btn.btn-link.small.text-muted[href=/signUp]', { oncreate: m.route.link }, 'Not a member? Sign Up')
     ]
   }
 }


### PR DESCRIPTION
## Proposed change/fix

Creates a feature flag for signup functionality. If `ENABLE_SIGNUP=false` in `.env.feature-flags`, then the signup button will not appear in the navbar and the signup route will render an empty page.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

- Open `.env.feature-flags` and set `ENABLE_SIGNUP=true`
- `npm run watch`
- Visit `http://localhost:8080/index_auditor.html`
  - Confirm that the signup button doesn't appear
  - Visit `http://localhost:8080/index_auditor.html#!/signUp` and confirm the page is empty