### PR TITLE
Add Combined Log format to Apache, including referrer and User Agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN echo -e "\
     AddDefaultCharset utf-8\n\
     LoadModule proxy_module modules/mod_proxy.so\n\
     LoadModule proxy_http_module modules/mod_proxy_http.so\n\
+    LogFormat \"%h %l %u %t \\\"%r\\\" %>s %b \\\"%{Referer}i\\\" \\\"%{User-agent}i\\\"\" combined\n\
+    CustomLog logs/access_log combined\n\
     ProxyPass /api/block-stream http://consensource-api:9010/push/0\n\
     ProxyPassReverse /api/block-stream http://consensource-api:9010/push/0\n\
     ProxyPass /api http://consensource-api:9009/api connectiontimeout=300 timeout=300\n\


### PR DESCRIPTION


## Proposed change/fix
Add Combined Log format to Apache, including referrer and User Agent to logs/access_log. Currently will not get picked up automatically by k8s logging or in docker-compose

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
`docker exec` into the `ui` image and verify accesses are logged in the file `logs/access_log`
