### PR TITLE
Add Certification Page

### DIFF
--- a/src/services/api/certificate.ts
+++ b/src/services/api/certificate.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { PaginatedApiRes } from './utils';
+import { BaseApiRes, PaginatedApiRes } from './utils';
 
 export interface CertResData {
   id: string;
@@ -26,6 +26,18 @@ export interface CertReqParam {
 export async function loadCertificates(params?: CertReqParam) {
   const res = await axios.get<PaginatedApiRes<CertResData[]>>(
     '/api/certificates',
+    { params },
+  );
+
+  return res.data;
+}
+
+export async function fetchCertificateById(
+  certId: string,
+  params?: CertReqParam,
+) {
+  const res = await axios.get<BaseApiRes<CertResData>>(
+    `/api/certificates/${certId}`,
     { params },
   );
 

--- a/src/view/components/Layout/Routes.tsx
+++ b/src/view/components/Layout/Routes.tsx
@@ -20,6 +20,14 @@ export const SharedRoutes = () => {
           },
         }) => <Pages.FactoryProfile factoryId={factoryId} />}
       />
+      <Route
+        path="/certifications/:certificationId"
+        render={({
+          match: {
+            params: { certificationId },
+          },
+        }) => <Pages.Certification certificationId={certificationId} />}
+      />
     </>
   );
 };

--- a/src/view/pages/Certification/CertBodyInfo.tsx
+++ b/src/view/pages/Certification/CertBodyInfo.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import { Typography, Grid, CircularProgress } from '@material-ui/core';
+import {
+  LoadingWithMinDisplay,
+  WarningIconError,
+  InfoItem,
+} from 'view/components';
+import { fetchOrganizationById, CertResData } from 'services/api';
+
+interface CertBodyInfoProps {
+  certificate: CertResData;
+}
+
+export function CertBodyInfo({ certificate }: CertBodyInfoProps) {
+  const { certifying_body_id, certifying_body } = certificate;
+  const { isLoading, error, data } = useQuery('fetchOrganizationById', () =>
+    fetchOrganizationById(certifying_body_id),
+  );
+
+  return (
+    <LoadingWithMinDisplay
+      isLoading={isLoading}
+      loadingIndicator={<CircularProgress />}
+    >
+      {error && (
+        <WarningIconError>Failed to load certifying body info</WarningIconError>
+      )}
+      {data && (
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <Typography variant="h4">Certifying Body Info</Typography>
+          </Grid>
+          <InfoItem title="Certifying Body" val={certifying_body} />
+        </Grid>
+      )}
+    </LoadingWithMinDisplay>
+  );
+}

--- a/src/view/pages/Certification/CertificateInfo.tsx
+++ b/src/view/pages/Certification/CertificateInfo.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Typography, Grid } from '@material-ui/core';
+import { CertResData } from 'services/api';
+import { InfoItem } from 'view/components';
+
+interface CertificateInfoProps {
+  certificate: CertResData;
+}
+
+export function CertificateInfo({ certificate }: CertificateInfoProps) {
+  const { standard_version, valid_from, valid_to } = certificate;
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <Typography variant="h4">Certificate Info</Typography>
+      </Grid>
+
+      <InfoItem title="Standard Version" val={standard_version} />
+      <InfoItem
+        title="Valid From"
+        val={new Date(valid_from).toLocaleDateString()}
+      />
+      <InfoItem
+        title="Valid To"
+        val={new Date(valid_to).toLocaleDateString()}
+      />
+    </Grid>
+  );
+}

--- a/src/view/pages/Certification/Certification.tsx
+++ b/src/view/pages/Certification/Certification.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import {
+  Typography,
+  Divider,
+  Grid,
+  makeStyles,
+  createStyles,
+} from '@material-ui/core';
+import {
+  LoadingWithMinDisplay,
+  SpinnerWithLabel,
+  WarningIconError,
+} from 'view/components';
+import { fetchCertificateById, CertResData } from 'services/api';
+import { CertificateInfo } from './CertificateInfo';
+import { CertBodyInfo } from './CertBodyInfo';
+
+const useStyles = makeStyles(({ palette }) =>
+  createStyles({
+    check: {
+      color: palette.success.main,
+    },
+    centeredText: {
+      textAlign: 'center',
+    },
+  }),
+);
+
+export interface CertificationProps {
+  certificationId: CertResData['id'];
+}
+
+export const Certification = ({ certificationId }: CertificationProps) => {
+  const { isLoading, error, data } = useQuery('fetchCertificateById', () =>
+    fetchCertificateById(certificationId),
+  );
+
+  const classes = useStyles();
+
+  return (
+    <LoadingWithMinDisplay
+      isLoading={isLoading}
+      loadingIndicator={
+        <SpinnerWithLabel label="Loading certificate info..." />
+      }
+    >
+      {error && (
+        <WarningIconError>Failed to load certification</WarningIconError>
+      )}
+
+      {data && (
+        <Grid container spacing={6}>
+          <Grid item xs={12}>
+            <Typography className={classes.centeredText} variant="h3">
+              {data.data.standard_name}
+            </Typography>
+            <Typography className={classes.centeredText} color="textSecondary">
+              {`Granted to: ${data.data.factory_name}`}
+            </Typography>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Divider variant="middle" />
+          </Grid>
+          <Grid item xs={12}>
+            <CertificateInfo certificate={data.data} />
+          </Grid>
+
+          <Grid item xs={12}>
+            <CertBodyInfo certificate={data.data} />
+          </Grid>
+        </Grid>
+      )}
+    </LoadingWithMinDisplay>
+  );
+};

--- a/src/view/pages/Certification/index.tsx
+++ b/src/view/pages/Certification/index.tsx
@@ -1,0 +1,1 @@
+export * from './Certification';

--- a/src/view/pages/index.tsx
+++ b/src/view/pages/index.tsx
@@ -5,3 +5,4 @@ export * from './Landing';
 export * from './Login';
 export * from './SearchFactories';
 export * from './SignUp';
+export * from './Certification';


### PR DESCRIPTION
## Proposed change/fix

- Same general layour as FactoryProfile page
- Displays standard name and factory name at top
- Includes two info sections for cert and cert body info, separate elements
- Add fetchCertificateById to api service
- Add /certifications/:certificationId route

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

1. Clone down the [consensource-compose](https://github.com/target/consensource-compose) repo:
```bash
 git clone --recurse-submodules https://github.com/target/consensource-compose.git
```
2. Make sure each submodule is up-to-date with the latest code changes
```sh
 git submodule update --remote $api
```
3. `cd api` and checkout this branch for api submodule
4. Build a local image for this image
```sh
 ./docker-helper.sh --build api
```
5. Build local images for other submodules as well if needed (`./docker-helper.sh --build local`)
6. Run `docker-compose -f docker-compose.run-local.yaml up`
7. Exec into the CLI container
8. Create an agent
```bash
 csrc agent create cliagent --url http://api:9009
```
9. Create an ingestion organization
```bash
 csrc organization create assertororg 4 assertercontactname 7632918628 ENG --city minneapolis --country usa --street_address '821 thor street' --url http://api:9009
```
10. Create a factory assertion
```
 csrc assertion factory create {org_id_here} testfactoryassertion1 yuki 6123982765 JPN --city osaka --country japan --street_address 'fukuoka south st' --state_province kanto --postal_code 55414 --url http://api:9009
```
11. Create a standard assertion
```
csrc assertion standard create {org_id_here} FSC-C 1.0 yeah link 1 --url http://api:9009
```
12. Create a certificate assertion
```
csrc assertion certificate create {assertor_id_here} {factory_id_here} 2 3 {standard_id_here} --url http://api:9009
```
13. View the `Certification` page at `http://localhost:3000/certifications/{cert_id_here}`