### PR TITLE
test: Add tests for Navbar components

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,8 +1,6 @@
-import * as H from 'history';
-
 declare global {
   /*
-   * Temporary type aliases to allow for easier incremental transition to TS
+   * Temporary type aliases that should be narrowed if/when possible
    */
   type $TSFixMe = any;
 

--- a/src/services/hooks/useSelectedRoute.ts
+++ b/src/services/hooks/useSelectedRoute.ts
@@ -1,4 +1,5 @@
 import { useLocation } from 'react-router-dom';
+
 /**
  * Custom hook that tracks changes to the `pathname` location
  * object and returns a boolean value indicating whether or

--- a/src/view/components/Layout/AuthenticatedLayout.tsx
+++ b/src/view/components/Layout/AuthenticatedLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useStores } from 'services/hooks';
 import { Snackbar, makeStyles, createStyles } from '@material-ui/core';
-import { AuthedNavBar, Sidebar, FullPageLoading } from 'view/components';
+import { AuthedNavbar, Sidebar, FullPageLoading } from 'view/components';
 import { QueryResult } from 'react-query';
 import { observer } from 'mobx-react-lite';
 import { AuthenticatedRoutes } from './Routes';
@@ -44,7 +44,7 @@ export const AuthenticatedLayout = observer(() => {
     >
       <div className={classes.container}>
         <nav>
-          <AuthedNavBar />
+          <AuthedNavbar />
           <Sidebar />
         </nav>
 

--- a/src/view/components/Layout/UnauthenticatedLayout.tsx
+++ b/src/view/components/Layout/UnauthenticatedLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Snackbar, makeStyles, createStyles } from '@material-ui/core';
 import { observer } from 'mobx-react-lite';
 import { useStores } from 'services/hooks';
-import { UnauthedNavBar } from 'view/components';
+import { UnauthedNavbar } from 'view/components';
 import { UnauthenticatedRoutes } from './Routes';
 
 const useStyles = makeStyles((theme) =>
@@ -21,7 +21,7 @@ export const UnauthenticatedLayout = observer(() => {
   return (
     <Grid alignItems="center" justify="center" container>
       <nav>
-        <UnauthedNavBar />
+        <UnauthedNavbar />
       </nav>
 
       <main className={classes.content}>

--- a/src/view/components/NavBar/Navbar.tsx
+++ b/src/view/components/NavBar/Navbar.tsx
@@ -18,8 +18,6 @@ export const NAVBAR_HEIGHT = 48;
 const useStyles = makeStyles(({ palette, zIndex }) =>
   createStyles({
     navbar: {
-      backgroundColor: palette.primary.main,
-      color: palette.primary.contrastText,
       zIndex: zIndex.drawer + 1,
     },
     logoContainer: {
@@ -30,6 +28,9 @@ const useStyles = makeStyles(({ palette, zIndex }) =>
     },
     divider: {
       backgroundColor: palette.primary.contrastText,
+    },
+    authItemsPadding: {
+      paddingRight: 10,
     },
   }),
 );
@@ -59,7 +60,7 @@ export const BaseNavBar: FC = ({ children: AuthItems }) => {
   );
 
   return (
-    <AppBar position="fixed" className={classes.navbar}>
+    <AppBar position="fixed" color="primary" className={classes.navbar}>
       <Toolbar variant="dense">
         {/* Note that all items after <Logo /> will be on the right side
         of the NavBar due to the `flexGrow: 1` styling */}
@@ -72,7 +73,7 @@ export const BaseNavBar: FC = ({ children: AuthItems }) => {
   );
 };
 
-export const UnauthedNavBar = () => {
+export const UnauthedNavbar = () => {
   return (
     <BaseNavBar>
       <NavbarLink label="Login" route="/login" />
@@ -80,7 +81,7 @@ export const UnauthedNavBar = () => {
   );
 };
 
-export const AuthedNavBar = () => {
+export const AuthedNavbar = () => {
   return (
     <BaseNavBar>
       <ProfileMenu />

--- a/src/view/components/NavBar/ProfileMenu.tsx
+++ b/src/view/components/NavBar/ProfileMenu.tsx
@@ -4,36 +4,49 @@ import {
   Menu,
   MenuItem,
   IconButton,
+  IconButtonProps,
   Typography,
-  makeStyles,
+  Grid,
 } from '@material-ui/core';
 import { useHistory } from 'react-router-dom';
 import { useStores } from 'services/hooks';
 import { observer } from 'mobx-react-lite';
 
-const useStyles = makeStyles({
-  profile: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-});
+export interface NavbarProfileIconProps {
+  onClick: IconButtonProps['onClick'];
+  username?: string;
+}
+
+export const NavbarProfileIcon = ({
+  onClick,
+  username,
+}: NavbarProfileIconProps) => {
+  return (
+    <IconButton
+      color="inherit"
+      aria-label="profile"
+      onClick={onClick}
+      edge="start"
+      data-testid="profile-icon-button"
+    >
+      <Grid container alignItems="center" spacing={1}>
+        <ProfileIcon />
+
+        {username && (
+          <Grid item>
+            <Typography data-testid="username">{username}</Typography>
+          </Grid>
+        )}
+      </Grid>
+    </IconButton>
+  );
+};
 
 export const ProfileMenu = observer(() => {
-  const history = useHistory();
   const { userStore } = useStores();
+  const history = useHistory();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-
-  const classes = useStyles();
-
   const username = userStore?.user?.username;
-
-  const handleIconClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   const handleLogout = () => {
     userStore.logout();
@@ -47,22 +60,15 @@ export const ProfileMenu = observer(() => {
 
   return (
     <div>
-      <div className={classes.profile}>
-        <IconButton
-          color="inherit"
-          aria-label="profile"
-          onClick={handleIconClick}
-          edge="start"
-        >
-          <ProfileIcon />
-        </IconButton>
-        <Typography>{username}</Typography>
-      </div>
+      <NavbarProfileIcon
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        username={username}
+      />
       <Menu
         keepMounted
         anchorEl={anchorEl}
         open={!!anchorEl}
-        onClose={handleClose}
+        onClose={() => setAnchorEl(null)}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'center',

--- a/src/view/components/NavBar/__tests__/Navbar.spec.tsx
+++ b/src/view/components/NavBar/__tests__/Navbar.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { AuthedNavbar, UnauthedNavbar } from '../Navbar';
+
+describe('<AuthedNavbar />', () => {
+  it('renders', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Route path="/">
+          <AuthedNavbar />
+        </Route>
+      </MemoryRouter>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe('<UnauthedNavbar />', () => {
+  it('renders', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Route path="/">
+          <UnauthedNavbar />
+        </Route>
+      </MemoryRouter>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/view/components/NavBar/__tests__/NavbarLink.spec.tsx
+++ b/src/view/components/NavBar/__tests__/NavbarLink.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { NavbarLink } from '../NavbarLink';
+
+describe('<NavbarLink />', () => {
+  it('renders an unselected link', () => {
+    const label = 'label';
+
+    const { container, getByText } = render(
+      <MemoryRouter initialEntries={['/test']}>
+        <Route path="/test">
+          <NavbarLink route="/" label={label} />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    expect(getByText(label).className.includes('selected')).toBe(false);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders a selected link', () => {
+    const label = 'label';
+
+    const { container, getByText } = render(
+      <MemoryRouter initialEntries={['/test']}>
+        <Route path="/test">
+          <NavbarLink route="/test" label={label} />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    expect(getByText(label).className.includes('selected')).toBe(true);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('sets the link target to "_blank" if "openInNewTab" is true', () => {
+    const { getByRole } = render(
+      <MemoryRouter initialEntries={['/test']}>
+        <Route path="/test">
+          <NavbarLink route="/test" label="test" openInNewTab />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    expect(getByRole('link')).toHaveAttribute('target', '_blank');
+  });
+
+  it('sets the link target to "" if "openInNewTab" is false', () => {
+    const { getByRole } = render(
+      <MemoryRouter initialEntries={['/test']}>
+        <Route path="/test">
+          <NavbarLink route="/test" label="test" />
+        </Route>
+      </MemoryRouter>,
+    );
+
+    expect(getByRole('link')).toHaveAttribute('target', '');
+  });
+});

--- a/src/view/components/NavBar/__tests__/ProfileMenu.spec.tsx
+++ b/src/view/components/NavBar/__tests__/ProfileMenu.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { StoresContext } from 'view/context';
+import { ProfileMenu } from '../ProfileMenu';
+
+const mockHistoryPush = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+describe('<ProfileMenu />', () => {
+  it('opens the profile menu on click', () => {
+    const { container, getByTestId, getByRole } = render(<ProfileMenu />);
+
+    fireEvent.click(getByTestId('profile-icon-button'));
+
+    expect(getByRole('menu')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders without a username', () => {
+    const { container, queryByTestId } = render(<ProfileMenu />);
+    expect(queryByTestId('username')).toBeNull();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders the username', () => {
+    const username = 'Bob';
+
+    const { container, getByTestId } = render(
+      <StoresContext.Provider
+        value={{ userStore: { user: { username } } } as any}
+      >
+        <ProfileMenu />
+      </StoresContext.Provider>,
+    );
+
+    expect(getByTestId('username').textContent).toBe(username);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('logs a user out and redirects to "/"', () => {
+    const { getByTestId, getByText } = render(
+      <StoresContext.Provider
+        value={{ userStore: { logout: mockLogout } } as any}
+      >
+        <ProfileMenu />
+      </StoresContext.Provider>,
+    );
+
+    fireEvent.click(getByTestId('profile-icon-button'));
+    fireEvent.click(getByText('Logout'));
+
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockHistoryPush).toHaveBeenCalledWith('/');
+  });
+
+  it('redirects a user to "/profile"', () => {
+    const { getByText, getByTestId } = render(<ProfileMenu />);
+
+    fireEvent.click(getByTestId('profile-icon-button'));
+    fireEvent.click(getByText('Profile'));
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/profile');
+  });
+});

--- a/src/view/components/NavBar/__tests__/__snapshots__/Navbar.spec.tsx.snap
+++ b/src/view/components/NavBar/__tests__/__snapshots__/Navbar.spec.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AuthedNavbar /> renders 1`] = `
+<div>
+  <header
+    class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-navbar-1 mui-fixed MuiPaper-elevation4"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-dense MuiToolbar-gutters"
+    >
+      <div
+        class="makeStyles-logoContainer-2"
+      >
+        <a
+          class="makeStyles-link-6"
+          href="/"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                ConsenSource
+              </h5>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <hr
+                class="MuiDivider-root makeStyles-divider-4 MuiDivider-vertical"
+              />
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <h6
+                class="MuiTypography-root makeStyles-persona-3 MuiTypography-h6"
+              >
+                Retailer
+              </h6>
+            </div>
+          </div>
+        </a>
+      </div>
+      <a
+        class="makeStyles-link-6"
+        href="http://consensource.io"
+        target="_blank"
+      >
+        <p
+          class="MuiTypography-root makeStyles-link-7 false MuiTypography-body1"
+        >
+          About
+        </p>
+      </a>
+      <a
+        class="makeStyles-link-6"
+        href="/search"
+        target=""
+      >
+        <p
+          class="MuiTypography-root makeStyles-link-7 false MuiTypography-body1"
+        >
+          Search Factories
+        </p>
+      </a>
+      <div>
+        <button
+          aria-label="profile"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
+          data-testid="profile-icon-button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-label"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                />
+              </svg>
+            </div>
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
+exports[`<UnauthedNavbar /> renders 1`] = `
+<div>
+  <header
+    class="MuiPaper-root MuiAppBar-root MuiAppBar-positionFixed MuiAppBar-colorPrimary makeStyles-navbar-9 mui-fixed MuiPaper-elevation4"
+  >
+    <div
+      class="MuiToolbar-root MuiToolbar-dense MuiToolbar-gutters"
+    >
+      <div
+        class="makeStyles-logoContainer-10"
+      >
+        <a
+          class="makeStyles-link-14"
+          href="/"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5"
+              >
+                ConsenSource
+              </h5>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <hr
+                class="MuiDivider-root makeStyles-divider-12 MuiDivider-vertical"
+              />
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item"
+            >
+              <h6
+                class="MuiTypography-root makeStyles-persona-11 MuiTypography-h6"
+              >
+                Retailer
+              </h6>
+            </div>
+          </div>
+        </a>
+      </div>
+      <a
+        class="makeStyles-link-14"
+        href="http://consensource.io"
+        target="_blank"
+      >
+        <p
+          class="MuiTypography-root makeStyles-link-15 false MuiTypography-body1"
+        >
+          About
+        </p>
+      </a>
+      <a
+        class="makeStyles-link-14"
+        href="/search"
+        target=""
+      >
+        <p
+          class="MuiTypography-root makeStyles-link-15 false MuiTypography-body1"
+        >
+          Search Factories
+        </p>
+      </a>
+      <a
+        class="makeStyles-link-14"
+        href="/login"
+        target=""
+      >
+        <p
+          class="MuiTypography-root makeStyles-link-15 false MuiTypography-body1"
+        >
+          Login
+        </p>
+      </a>
+    </div>
+  </header>
+</div>
+`;

--- a/src/view/components/NavBar/__tests__/__snapshots__/NavbarLink.spec.tsx.snap
+++ b/src/view/components/NavBar/__tests__/__snapshots__/NavbarLink.spec.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NavbarLink /> renders a selected link 1`] = `
+<div>
+  <a
+    class="makeStyles-link-6"
+    href="/test"
+    target=""
+  >
+    <p
+      class="MuiTypography-root makeStyles-link-4 makeStyles-selected-5 MuiTypography-body1"
+    >
+      label
+    </p>
+  </a>
+</div>
+`;
+
+exports[`<NavbarLink /> renders an unselected link 1`] = `
+<div>
+  <a
+    class="makeStyles-link-3"
+    href="/"
+    target=""
+  >
+    <p
+      class="MuiTypography-root makeStyles-link-1 false MuiTypography-body1"
+    >
+      label
+    </p>
+  </a>
+</div>
+`;

--- a/src/view/components/NavBar/__tests__/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/src/view/components/NavBar/__tests__/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProfileMenu /> opens the profile menu on click 1`] = `
+<div
+  aria-hidden="true"
+>
+  <div>
+    <button
+      aria-label="profile"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
+      data-testid="profile-icon-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+            />
+          </svg>
+        </div>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<ProfileMenu /> renders the username 1`] = `
+<div>
+  <div>
+    <button
+      aria-label="profile"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
+      data-testid="profile-icon-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+            />
+          </svg>
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1"
+              data-testid="username"
+            >
+              Bob
+            </p>
+          </div>
+        </div>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<ProfileMenu /> renders without a username 1`] = `
+<div>
+  <div>
+    <button
+      aria-label="profile"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
+      data-testid="profile-icon-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiIconButton-label"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+            />
+          </svg>
+        </div>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

- Adds tests for the components in `view/components/Navbar/`
- Correct spelling from `NavBar` to `Navbar`
- Remove unused import in `global.d.ts`
- Remove empty folders/files for tests that are yet to be authored
- Fix small bug where an empty `<Typography />` was being rendered in the navbar
- Breakout part of the `<ProfileMenu />` into a smaller `<NavbarProfileIcon />` component

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Testing

## How to run/test

`yarn test src/view/components/NavBar/__tests__`
