### PR TITLE
fix: show agent info on error response

### DIFF
--- a/src/view/pages/UserProfile/AgentAccordion.tsx
+++ b/src/view/pages/UserProfile/AgentAccordion.tsx
@@ -32,7 +32,10 @@ export const AgentAccordion = ({ agentPubKey }: AgentAccordionProps) => {
       </AccordionSummary>
 
       <AccordionDetails>
-        <LoadingWithMinDisplay queryRes={queryRes}>
+        <LoadingWithMinDisplay
+          queryRes={queryRes}
+          errorIndicator={<AgentInfo agent={null} />}
+        >
           {({ data }) => <AgentInfo agent={data} />}
         </LoadingWithMinDisplay>
       </AccordionDetails>


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Fixes a bug where the Agent Accordion would continually try to fetch an agent if a 4XX response is returned. When a user first signs up, they do not have an agent, so this should instead just display the Agent Signup form, rather than display an error.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

- Create a new user
- Visit the profile page
- Expand the `Advanced` accordion
- Confirm that the agent signup form is displayed
