### PR TITLE
fix: update broken protobuf tests

### DIFF
--- a/src/services/protobuf/__tests__/agent.spec.ts
+++ b/src/services/protobuf/__tests__/agent.spec.ts
@@ -1,19 +1,17 @@
-import {
-  createAgentTransaction,
-  getAgentStateAddress,
-} from 'services/protobuf/agent';
 import { createSigner, createNewPrivateKey } from 'services/crypto';
-import { CertificateRegistryPayload } from 'services/protobuf/compiled';
 import { TransactionHeader } from 'sawtooth-sdk/protobuf';
-import { ACTIONS } from 'services/protobuf/transaction';
+import { getAgentStateAddress } from 'services/addressing';
+import { createAgentTransaction, createAgentAction } from '../agent';
+import { CertificateRegistryPayload } from '../compiled';
+import { ACTIONS } from '../utils';
 
 describe('Agent Protobuf', () => {
   describe('createAgentTransaction()', () => {
-    const agent: IAgent = { name: 'test' };
+    const agent_action = createAgentAction({ name: 'test' });
     const signer = createSigner(createNewPrivateKey());
 
     it('creates a new CreateAgentAction and wraps it in a transaction', () => {
-      const txn = createAgentTransaction(agent, signer);
+      const txn = createAgentTransaction(agent_action, signer);
 
       const payload = CertificateRegistryPayload.decode(txn.payload);
       const { inputs, outputs } = TransactionHeader.decode(txn.header);

--- a/src/services/protobuf/__tests__/assertion.spec.ts
+++ b/src/services/protobuf/__tests__/assertion.spec.ts
@@ -1,10 +1,4 @@
-import * as AssertionService from 'services/protobuf/assertion';
 import { createSigner, createNewPrivateKey } from 'services/crypto';
-import {
-  CertificateRegistryPayload,
-  Organization,
-  Factory,
-} from 'services/protobuf/compiled';
 import {
   createStateAddress,
   getAgentStateAddress,
@@ -12,9 +6,11 @@ import {
   FAMILY_NAMESPACE,
   RESERVED_NAMESPACE,
 } from 'services/addressing';
-import { createOrgAction } from 'services/protobuf/organization';
 import { TransactionHeader } from 'sawtooth-sdk/protobuf';
-import { ACTIONS } from 'services/protobuf/transaction';
+import * as AssertionService from '../assertion';
+import { CertificateRegistryPayload, Organization, Factory } from '../compiled';
+import { createOrgAction } from '../organization';
+import { ACTIONS } from '../utils';
 
 describe('Assertion Protobuf', () => {
   describe('createAssertionActionTransaction()', () => {

--- a/src/services/protobuf/__tests__/batch.spec.ts
+++ b/src/services/protobuf/__tests__/batch.spec.ts
@@ -1,10 +1,10 @@
-import createBatch from 'services/protobuf/batch';
 import {
   createSigner,
   createNewPrivateKey,
   cryptoContext,
 } from 'services/crypto';
 import { Transaction, BatchHeader, BatchList } from 'sawtooth-sdk/protobuf';
+import { createBatch } from '../batch';
 
 describe('Batch Protobuf', () => {
   const signer = createSigner(createNewPrivateKey());

--- a/src/services/protobuf/__tests__/organization.spec.ts
+++ b/src/services/protobuf/__tests__/organization.spec.ts
@@ -4,17 +4,10 @@ import {
   ConsenSourceNamespaces,
 } from 'services/addressing';
 import { createSigner, createNewPrivateKey } from 'services/crypto';
-import {
-  CertificateRegistryPayload,
-  Organization,
-  Factory,
-} from 'services/protobuf/compiled';
 import { TransactionHeader } from 'sawtooth-sdk/protobuf';
-import { ACTIONS } from 'services/protobuf/transaction';
-import {
-  createOrgAction,
-  createOrgTransaction,
-} from 'services/protobuf/organization';
+import { CertificateRegistryPayload, Organization, Factory } from '../compiled';
+import { ACTIONS } from '../utils';
+import { createOrgAction, createOrgTransaction } from '../organization';
 
 describe('Organization Protobuf', () => {
   describe('createOrgTransaction()', () => {

--- a/src/services/protobuf/__tests__/transaction.ts
+++ b/src/services/protobuf/__tests__/transaction.ts
@@ -1,13 +1,9 @@
-import {
-  getTxnTimestamp,
-  ACTIONS,
-  encodePayload,
-  getTransactionIds,
-  createTransaction,
-} from 'services/protobuf/transaction';
-import { CertificateRegistryPayload } from 'services/protobuf/compiled';
 import { Transaction, TransactionHeader } from 'sawtooth-sdk/protobuf';
-import { FAMILY_NAME, FAMILY_VERSION } from 'services/addressing';
+import {
+  FAMILY_NAME,
+  FAMILY_VERSION,
+  getAgentStateAddress,
+} from 'services/addressing';
 import {
   createSigner,
   createNewPrivateKey,
@@ -15,38 +11,9 @@ import {
   hash,
   HashingAlgorithms,
 } from 'services/crypto';
-
-import { getAgentStateAddress } from '../agent';
+import { getTransactionIds, createTransaction } from '../transaction';
 
 describe('Transaction Protobuf', () => {
-  describe('getTxnTimestamp', () => {
-    let dateSpy: jest.SpyInstance;
-    const now = 10000;
-
-    beforeAll(() => {
-      dateSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
-    });
-
-    afterAll(() => dateSpy.mockRestore());
-
-    it('returns the date divided by 1000', () => {
-      expect(getTxnTimestamp()).toBe(now / 1000);
-    });
-  });
-
-  describe('encodePayload()', () => {
-    it('encodes and returns a CertificateRegistryPayload', () => {
-      const payload: ICertificateRegistryPayload = {
-        action: ACTIONS.FACTORY,
-      };
-
-      const encoded = encodePayload(payload);
-      const decoded = CertificateRegistryPayload.decode(encoded);
-
-      expect(decoded).toEqual(payload);
-    });
-  });
-
   describe('getTransactionIds()', () => {
     it('returns an array of transaction ids, where each ID is the `headerSignature` of the transaction', () => {
       const headerSignatures = ['1', '2'];

--- a/src/services/protobuf/__tests__/utils.spec.ts
+++ b/src/services/protobuf/__tests__/utils.spec.ts
@@ -1,0 +1,18 @@
+import { ACTIONS, encodePayload } from '../utils';
+import {
+  CertificateRegistryPayload,
+  ICertificateRegistryPayload,
+} from '../compiled';
+
+describe('encodePayload()', () => {
+  it('encodes and returns a CertificateRegistryPayload', () => {
+    const payload: ICertificateRegistryPayload = {
+      action: ACTIONS.UNSET_ACTION,
+    };
+
+    const encoded = encodePayload(payload);
+    const decoded = CertificateRegistryPayload.decode(encoded);
+
+    expect(decoded).toEqual(payload);
+  });
+});

--- a/src/services/protobuf/batch.ts
+++ b/src/services/protobuf/batch.ts
@@ -1,6 +1,6 @@
 import { Batch, BatchHeader, BatchList } from 'sawtooth-sdk/protobuf';
-import { getTransactionIds } from 'services/protobuf/transaction';
 import { getSignerPubKeyHex } from 'services/crypto';
+import { getTransactionIds } from './transaction';
 
 /**
  * Creates a serialized `BatchHeader`, signs the message,

--- a/src/services/protobuf/certificate.ts
+++ b/src/services/protobuf/certificate.ts
@@ -3,17 +3,9 @@ import {
   createStateAddress,
   getAgentStateAddress,
 } from 'services/addressing';
-import {
-  IssueCertificateAction,
-  ICertificateRegistryPayload,
-  IIssueCertificateAction,
-} from 'services/protobuf/compiled';
-import {
-  createTransaction,
-  PayloadInfo,
-  encodePayload,
-  ACTIONS,
-} from 'services/protobuf/transaction';
+import { IssueCertificateAction, IIssueCertificateAction } from './compiled';
+import { createTransaction } from './transaction';
+import { encodePayload, PayloadInfo, ACTIONS } from './utils';
 
 /**
  * Interface to define the minimum required properties for an `IIssueCertificateAction`,
@@ -109,17 +101,14 @@ export function createIssueCertTransaction(
   cert_body_id: string,
   signer: sawtooth.signing.Signer,
 ) {
-  const payload: ICertificateRegistryPayload = {
-    action: ACTIONS.ISSUE_CERTIFICATE,
-    issue_certificate,
+  const payloadInfo: PayloadInfo = {
+    inputs: getInputAddresses(issue_certificate, cert_body_id, signer),
+    outputs: getOutputAddresses(issue_certificate),
+    payloadBytes: encodePayload({
+      action: ACTIONS.ISSUE_CERTIFICATE,
+      issue_certificate,
+    }),
   };
-
-  const payloadBytes = encodePayload(payload);
-
-  const inputs = getInputAddresses(issue_certificate, cert_body_id, signer);
-  const outputs = getOutputAddresses(issue_certificate);
-
-  const payloadInfo: PayloadInfo = { payloadBytes, inputs, outputs };
 
   return createTransaction(payloadInfo, signer);
 }

--- a/src/services/protobuf/transaction.ts
+++ b/src/services/protobuf/transaction.ts
@@ -1,21 +1,10 @@
 import { hash, HashingAlgorithms, getSignerPubKeyHex } from 'services/crypto';
 import { Transaction, TransactionHeader } from 'sawtooth-sdk/protobuf';
 import {
-  CertificateRegistryPayload,
-  ICertificateRegistryPayload,
-} from 'services/protobuf/compiled';
-import {
   FAMILY_NAME as familyName,
   FAMILY_VERSION as familyVersion,
 } from 'services/addressing';
-
-export interface PayloadInfo {
-  payloadBytes: string | Buffer | NodeJS.TypedArray | DataView;
-  inputs: string[];
-  outputs: string[];
-}
-
-export const ACTIONS = CertificateRegistryPayload.Action;
+import { PayloadInfo } from './utils';
 
 /**
  * Create an array of transaction IDs, where each ID is the `headerSignature`
@@ -25,23 +14,6 @@ export function getTransactionIds(
   transactions: sawtooth.protobuf.Transaction[],
 ): string[] {
   return transactions.map((transaction) => transaction.headerSignature);
-}
-
-/**
- * Encodes a CertificateRegistryPayload message
- * @param message CertificateRegistryPayload message or plain object to encode
- */
-export function encodePayload(
-  payload: ICertificateRegistryPayload,
-): Uint8Array {
-  return CertificateRegistryPayload.encode(payload).finish();
-}
-
-/**
- * Default timestamp logic for transactions.
- */
-export function getTxnTimestamp() {
-  return Math.round(Date.now() / 1000);
 }
 
 /**

--- a/src/services/protobuf/utils.ts
+++ b/src/services/protobuf/utils.ts
@@ -1,0 +1,22 @@
+import {
+  CertificateRegistryPayload,
+  ICertificateRegistryPayload,
+} from './compiled';
+
+export interface PayloadInfo {
+  payloadBytes: string | Buffer | NodeJS.TypedArray | DataView;
+  inputs: string[];
+  outputs: string[];
+}
+
+export const ACTIONS = CertificateRegistryPayload.Action;
+
+/**
+ * Encodes a CertificateRegistryPayload message
+ * @param message CertificateRegistryPayload message or plain object to encode
+ */
+export function encodePayload(
+  payload: ICertificateRegistryPayload,
+): Uint8Array {
+  return CertificateRegistryPayload.encode(payload).finish();
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,7 @@
+export function getUnixTimeSec() {
+  return Math.floor(Date.now() / 1000);
+}
+
 export function getLocaleFromUnix(timestampSeconds: number) {
   const timestampMs = timestampSeconds * 1000;
   return new Date(timestampMs).toLocaleDateString();

--- a/src/view/forms/organization/CreateFactoryAddress.tsx
+++ b/src/view/forms/organization/CreateFactoryAddress.tsx
@@ -7,7 +7,7 @@ import {
 import { Factory } from 'services/protobuf/compiled';
 import { Button, Grid, TextField, Typography } from '@material-ui/core';
 
-interface CreateContactFormProps {
+interface CreateFactoryAddressFormProps {
   onSubmit: (address: Factory.Address) => any;
   submitLabel?: string;
 }
@@ -18,7 +18,7 @@ interface CreateContactFormProps {
 export const CreateFactoryAddressForm = ({
   onSubmit,
   submitLabel = 'Submit',
-}: CreateContactFormProps) => {
+}: CreateFactoryAddressFormProps) => {
   const [address, setAddress] = useState<IFactoryAddressStrict>({
     street_line_1: '',
     city: '',


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

- Fixes broken tests in `services/protobuf`
- Changes copy/paste prop name error for `CreateFactoryAddressForm`
- Also removes verbose imports to use relative paths in `services/protobuf`

## Types of changes

What types of changes does this pull request introduce?

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Visual change (includes a change visible to an end user)
-   [x] Other (refactor)

## Screenshots (visual updates only)

N/A

## How to run/test

```
yarn test src/services/protobuf
```
