### PR TITLE
refactor: use uuid for org names

### DIFF
--- a/src/services/__tests__/addressing.spec.ts
+++ b/src/services/__tests__/addressing.spec.ts
@@ -1,16 +1,9 @@
-import {
-  createStateAddress,
-  ConsenSourceNamespaces,
-  ADDRESS_LEN,
-  FAMILY_NAMESPACE,
-  RESERVED_NAMESPACE,
-  FAMILY_NAMESPACE_LEN,
-} from 'services/addressing';
+import * as addressing from 'services/addressing';
 
 it('creates an address of 70 chars with the correct namespace prefixes', () => {
   const [reservedNamespaceStart, reservedNamespaceEnd] = [
-    FAMILY_NAMESPACE_LEN,
-    FAMILY_NAMESPACE_LEN + 2,
+    addressing.FAMILY_NAMESPACE_LEN,
+    addressing.FAMILY_NAMESPACE_LEN + 2,
   ];
 
   const [txnNamespaceStart, txnNamespaceEnd] = [
@@ -18,19 +11,34 @@ it('creates an address of 70 chars with the correct namespace prefixes', () => {
     reservedNamespaceEnd + 2,
   ];
 
-  const address = createStateAddress(
-    ConsenSourceNamespaces.ORGANIZATION,
+  const address = addressing.createStateAddress(
+    addressing.ConsenSourceNamespaces.ORGANIZATION,
     'test',
   );
 
-  expect(address.length).toEqual(ADDRESS_LEN);
-  expect(address.substring(0, FAMILY_NAMESPACE_LEN)).toEqual(FAMILY_NAMESPACE);
+  expect(address.length).toEqual(addressing.ADDRESS_LEN);
+  expect(address.substring(0, addressing.FAMILY_NAMESPACE_LEN)).toEqual(
+    addressing.FAMILY_NAMESPACE,
+  );
 
   expect(
     address.substring(reservedNamespaceStart, reservedNamespaceEnd),
-  ).toEqual(RESERVED_NAMESPACE);
+  ).toEqual(addressing.RESERVED_NAMESPACE);
 
   expect(address.substring(txnNamespaceStart, txnNamespaceEnd)).toEqual(
-    ConsenSourceNamespaces.ORGANIZATION,
+    addressing.ConsenSourceNamespaces.ORGANIZATION,
   );
+});
+
+it('creates a namespace prefix that concatenates the family namespace, reserved namespace, and txn namespace', () => {
+  const prefix =
+    addressing.FAMILY_NAMESPACE +
+    addressing.RESERVED_NAMESPACE +
+    addressing.ConsenSourceNamespaces.AGENT;
+
+  expect(
+    addressing.getNamespaceWithPrefix(addressing.ConsenSourceNamespaces.AGENT),
+  ).toEqual(prefix);
+
+  expect(prefix.length).toEqual(addressing.ADDRESS_PREFIX_LEN);
 });

--- a/src/services/protobuf/__tests__/agent.spec.ts
+++ b/src/services/protobuf/__tests__/agent.spec.ts
@@ -1,7 +1,10 @@
 import { createSigner, createNewPrivateKey } from 'services/crypto';
 import { TransactionHeader } from 'sawtooth-sdk/protobuf';
-import { createAgentStateAddress } from 'services/addressing';
-import { createAgentTransaction, createAgentAction } from '../agent';
+import {
+  createAgentTransaction,
+  createAgentAction,
+  createAgentStateAddress,
+} from '../agent';
 import { CertificateRegistryPayload } from '../compiled';
 import { ACTIONS } from '../utils';
 
@@ -9,6 +12,7 @@ describe('Agent Protobuf', () => {
   describe('createAgentTransaction()', () => {
     const agent_action = createAgentAction({ name: 'test' });
     const signer = createSigner(createNewPrivateKey());
+    const addresses = [createAgentStateAddress(signer)];
 
     it('creates a new CreateAgentAction and wraps it in a transaction', () => {
       const txn = createAgentTransaction(agent_action, signer);
@@ -17,8 +21,8 @@ describe('Agent Protobuf', () => {
       const { inputs, outputs } = TransactionHeader.decode(txn.header);
 
       expect(payload.action).toBe(ACTIONS.CREATE_AGENT);
-      expect(inputs).toEqual([createAgentStateAddress(signer)]);
-      expect(outputs).toEqual([createAgentStateAddress(signer)]);
+      expect(inputs).toEqual(addresses);
+      expect(outputs).toEqual(addresses);
     });
   });
 });

--- a/src/services/protobuf/__tests__/organization.spec.ts
+++ b/src/services/protobuf/__tests__/organization.spec.ts
@@ -1,21 +1,19 @@
-import { createAgentStateAddress, createOrgAddress } from 'services/addressing';
 import { createSigner, createNewPrivateKey } from 'services/crypto';
 import { TransactionHeader } from 'sawtooth-sdk/protobuf';
 import { CertificateRegistryPayload, Organization, Factory } from '../compiled';
 import { ACTIONS } from '../utils';
 import {
   createOrgAction,
+  createOrgStateAddress,
   createOrgTransaction,
   updateOrgAction,
   updateOrgTransaction,
 } from '../organization';
+import { createAgentStateAddress } from '../agent';
 
 describe('Organization Protobuf', () => {
   describe('createOrgTransaction()', () => {
-    const id = 'test';
-
     const org = createOrgAction({
-      id,
       organization_type: Organization.Type.FACTORY,
       contacts: [new Organization.Contact()],
       address: new Factory.Address(),
@@ -24,7 +22,10 @@ describe('Organization Protobuf', () => {
 
     const signer = createSigner(createNewPrivateKey());
 
-    const addresses = [createOrgAddress(id), createAgentStateAddress(signer)];
+    const addresses = [
+      createOrgStateAddress(org.id),
+      createAgentStateAddress(signer),
+    ];
 
     it('creates a new CreateOrganizationAction and wraps it in a transaction', () => {
       const txn = createOrgTransaction(org, signer);
@@ -37,7 +38,7 @@ describe('Organization Protobuf', () => {
       expect(outputs).toEqual(addresses);
     });
   });
-  
+
   describe('updateOrgTransaction()', () => {
     const org = updateOrgAction({
       contacts: [new Organization.Contact()],
@@ -48,7 +49,10 @@ describe('Organization Protobuf', () => {
 
     const signer = createSigner(createNewPrivateKey());
 
-    const addresses = [createOrgAddress(name), createAgentStateAddress(signer)];
+    const addresses = [
+      createOrgStateAddress(name),
+      createAgentStateAddress(signer),
+    ];
 
     it('creates a new UpdateOrganizationAction and wraps it in a transaction', () => {
       const txn = updateOrgTransaction(org, signer, name);

--- a/src/services/protobuf/__tests__/transaction.ts
+++ b/src/services/protobuf/__tests__/transaction.ts
@@ -1,9 +1,5 @@
 import { Transaction, TransactionHeader } from 'sawtooth-sdk/protobuf';
-import {
-  FAMILY_NAME,
-  FAMILY_VERSION,
-  createAgentStateAddress,
-} from 'services/addressing';
+import { FAMILY_NAME, FAMILY_VERSION } from 'services/addressing';
 import {
   createSigner,
   createNewPrivateKey,
@@ -11,6 +7,7 @@ import {
   hash,
   HashingAlgorithms,
 } from 'services/crypto';
+import { createAgentStateAddress } from '../agent';
 import { getTransactionIds, createTransaction } from '../transaction';
 
 describe('Transaction Protobuf', () => {
@@ -30,11 +27,12 @@ describe('Transaction Protobuf', () => {
     const signer = createSigner(createNewPrivateKey());
     const pubKey = signer.getPublicKey();
     const payload = 'test-payloadBytes';
+    const addresses = [createAgentStateAddress(signer)];
 
     const mockTransactionPayload = {
       payloadBytes: Buffer.from(payload),
-      inputs: [createAgentStateAddress(signer)],
-      outputs: [createAgentStateAddress(signer)],
+      inputs: addresses,
+      outputs: addresses,
     };
 
     const transactionHeaderBytes = {

--- a/src/services/protobuf/agent.ts
+++ b/src/services/protobuf/agent.ts
@@ -1,5 +1,9 @@
-import { createAgentStateAddress } from 'services/addressing';
+import {
+  ConsenSourceNamespaces,
+  createStateAddress,
+} from 'services/addressing';
 import { getUnixTimeSec } from 'utils';
+import { getSignerPubKeyHex } from 'services/crypto';
 import { createTransaction } from './transaction';
 import { CreateAgentAction, ICreateAgentAction } from './compiled';
 import { PayloadInfo, ACTIONS, encodePayload } from './utils';
@@ -18,6 +22,16 @@ export interface ICreateAgentActionStrict extends ICreateAgentAction {
  */
 export type CreateAgentActionStrict = ICreateAgentActionStrict &
   CreateAgentAction;
+
+/**
+ * Helper function to get the agent address from the public key of a signer.
+ */
+export function createAgentStateAddress(signer: sawtooth.signing.Signer) {
+  return createStateAddress(
+    ConsenSourceNamespaces.AGENT,
+    getSignerPubKeyHex(signer),
+  );
+}
 
 /**
  * Create a `CreateAgentAction` that can be included

--- a/src/services/protobuf/certificate.ts
+++ b/src/services/protobuf/certificate.ts
@@ -1,8 +1,8 @@
 import {
   ConsenSourceNamespaces,
   createStateAddress,
-  createAgentStateAddress,
 } from 'services/addressing';
+import { createAgentStateAddress } from './agent';
 import { IssueCertificateAction, IIssueCertificateAction } from './compiled';
 import { createTransaction } from './transaction';
 import { encodePayload, PayloadInfo, ACTIONS } from './utils';

--- a/src/view/forms/organization/Organization.tsx
+++ b/src/view/forms/organization/Organization.tsx
@@ -5,7 +5,6 @@ import {
   createOrgTransaction,
 } from 'services/protobuf/organization';
 import { Organization } from 'services/protobuf/compiled';
-import { hash, HashingAlgorithms } from 'services/crypto';
 import { VpnKey as Key } from '@material-ui/icons';
 import { Button, Typography, Grid, TextField } from '@material-ui/core';
 import { SelectOrganizationType } from 'view/forms/organization/SelectOrganizationType';
@@ -15,8 +14,6 @@ import { FormErrMsg, TransactionFormProps } from 'view/forms/utils';
 import { postBatches } from 'services/api';
 import { CreateContactForm } from './CreateContact';
 import { CreateFactoryAddressForm } from './CreateFactoryAddress';
-
-const makeOrgId = (name: string) => hash(name, HashingAlgorithms.sha256);
 
 /**
  * Four-part form used to build a `CreateOrganizationAction` payload object
@@ -35,14 +32,13 @@ export const CreateOrganizationForm = ({
     contacts: [] as Organization.IContact[],
     address: null,
     name: '',
-    id: '',
     organization_type: Organization.Type.UNSET_TYPE,
   });
 
   const submit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    const action = createOrgAction({ ...org, id: makeOrgId(org.name) });
+    const action = createOrgAction(org);
     const txns = new Array(createOrgTransaction(action, signer));
     const batchListBytes = createBatch(txns, signer);
 


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

- use uuid for org names instead of hashing the name of the org
- refactor addressing logic to live in protobuf files

## Types of changes

What types of changes does this pull request introduce?

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Visual change (includes a change visible to an end user)
-   [x] Other (refactor)

## Screenshots (visual updates only)

N/A

## How to run/test

`yarn test src/services/protobuf`