### PR TITLE
fix: use correct unix time

### DIFF
--- a/src/view/cards/Certification/Body.tsx
+++ b/src/view/cards/Certification/Body.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid, Typography, makeStyles, createStyles } from '@material-ui/core';
 import { CertResData } from 'services/api';
-import { getLocaleFromUnix } from 'utils';
+import { getLocaleFromUnix, getUnixTimeSec } from 'utils';
 import {
   CheckIcon,
   WarningIcon,
@@ -51,8 +51,7 @@ const useStyles = makeStyles(({ palette }) =>
 const ValidToText = ({ validTo }: ValidToTextProps) => {
   const classes = useStyles();
 
-  const validToMs = validTo * 1000;
-  const isValid = validToMs >= Date.now();
+  const isValid = validTo >= getUnixTimeSec();
   const text = isValid ? 'Valid until' : 'Expired on';
 
   return (
@@ -68,7 +67,7 @@ const ValidToText = ({ validTo }: ValidToTextProps) => {
         <Typography
           variant="body1"
           className={classes.validToText}
-        >{`${text} ${getLocaleFromUnix(validToMs)}`}</Typography>
+        >{`${text} ${getLocaleFromUnix(validTo)}`}</Typography>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Fixes a bug where the cert card body was using the wrong unix timestamp.

## Types of changes

What types of changes does this pull request introduce?

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Visual change (includes a change visible to an end user)
-   [ ] Other (could be a small readme update, documentation contribution, etc.)

## Screenshots (visual updates only)

Include a screenshot of any visual changes.

## How to run/test

- Create a cert
- Verify that timestamp is formatted properly