### PR TITLE
bugfix: remove usage of claimed btn in cert card

### DIFF
--- a/src/view/cards/Certification/Body.tsx
+++ b/src/view/cards/Certification/Body.tsx
@@ -3,23 +3,19 @@ import { Grid, Typography, makeStyles, createStyles } from '@material-ui/core';
 import { CertResData } from 'services/api';
 import { getLocaleFromUnix, getUnixTimeSec } from 'utils';
 import {
-  CheckIcon,
-  WarningIcon,
-  ClaimedIconButton,
-  UnclaimedIconButton,
+  AssignmentTurnedInOutlined as CheckIcon,
+  Warning as WarningIcon,
+  VerifiedUserOutlined as ClaimedIcon,
+  InfoOutlined as UnclaimedIcon,
 } from 'view/components';
 
 export interface BodyProps {
   validTo: CertResData['valid_to'];
   isClaimed: boolean;
 }
-
-export interface ValidToTextProps {
-  validTo: BodyProps['validTo'];
-}
-
-export interface IsClaimedTextProps {
-  isClaimed: BodyProps['isClaimed'];
+export interface BodyRowProps {
+  text: string;
+  icon: JSX.Element;
 }
 
 const useStyles = makeStyles(({ palette }) =>
@@ -27,71 +23,46 @@ const useStyles = makeStyles(({ palette }) =>
     success: {
       color: palette.success.main,
     },
-    warning: {
-      color: palette.warning.main,
-    },
-    claimedText: {
-      paddingTop: 12.5,
-    },
-    claimedBtn: {
-      marginLeft: 2.5,
-    },
-    validToIcon: {
-      padding: '18px 16px 16px 16px !important',
-    },
-    validToText: {
-      marginLeft: 12,
-    },
-    validToRow: {
-      paddingLeft: 15,
+    info: {
+      color: palette.info.main,
     },
   }),
 );
 
-const ValidToText = ({ validTo }: ValidToTextProps) => {
-  const classes = useStyles();
-
-  const isValid = validTo >= getUnixTimeSec();
-  const text = isValid ? 'Valid until' : 'Expired on';
-
+const BodyRow = ({ icon, text }: BodyRowProps) => {
   return (
-    <Grid container item spacing={4} className={classes.validToRow}>
-      <Grid item xs={1} className={classes.validToIcon}>
-        {isValid ? (
-          <CheckIcon className={classes.success} />
-        ) : (
-          <WarningIcon color="error" />
-        )}
+    <Grid container item spacing={4}>
+      <Grid item xs={2}>
+        {icon}
       </Grid>
       <Grid item xs>
-        <Typography
-          variant="body1"
-          className={classes.validToText}
-        >{`${text} ${getLocaleFromUnix(validTo)}`}</Typography>
-      </Grid>
-    </Grid>
-  );
-};
-
-const IsClaimedText = ({ isClaimed }: IsClaimedTextProps) => {
-  const classes = useStyles();
-  const isClaimedText = isClaimed ? 'Claimed' : 'Unclaimed';
-
-  return (
-    <Grid container item spacing={6}>
-      <Grid item xs={2} className={classes.claimedBtn}>
-        {isClaimed ? <ClaimedIconButton /> : <UnclaimedIconButton />}
-      </Grid>
-      <Grid item xs>
-        <Typography variant="body1" className={classes.claimedText}>
-          {isClaimedText}
-        </Typography>
+        <Typography variant="body1">{text}</Typography>
       </Grid>
     </Grid>
   );
 };
 
 export const Body = ({ validTo, isClaimed }: BodyProps) => {
+  const classes = useStyles();
+
+  const isClaimedText = isClaimed ? 'Claimed' : 'Unclaimed';
+  const isClaimedIcon = isClaimed ? (
+    <ClaimedIcon className={classes.success} />
+  ) : (
+    <UnclaimedIcon className={classes.info} />
+  );
+
+  const isValid = validTo >= getUnixTimeSec();
+  const validToLocale = getLocaleFromUnix(validTo);
+  const isValidText = isValid
+    ? `Valid until ${validToLocale}`
+    : `Expired on ${validToLocale}`;
+  const isValidIcon = isValid ? (
+    <CheckIcon className={classes.success} />
+  ) : (
+    <WarningIcon color="error" />
+  );
+
   return (
     <Grid container direction="column" spacing={1}>
       <Grid item>
@@ -101,11 +72,11 @@ export const Body = ({ validTo, isClaimed }: BodyProps) => {
       </Grid>
 
       <Grid item>
-        <IsClaimedText isClaimed={isClaimed} />
+        <BodyRow text={isClaimedText} icon={isClaimedIcon} />
       </Grid>
 
       <Grid item>
-        <ValidToText validTo={validTo} />
+        <BodyRow text={isValidText} icon={isValidIcon} />
       </Grid>
     </Grid>
   );

--- a/src/view/components/Claims/UnclaimedIconButton.tsx
+++ b/src/view/components/Claims/UnclaimedIconButton.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { InfoOutlined as InfoIcon } from '@material-ui/icons';
 import {
   Tooltip,
   IconButton,
@@ -9,6 +8,7 @@ import {
   Theme,
 } from '@material-ui/core';
 import { UnclaimedDialog } from 'view/modals';
+import { InfoOutlined as InfoIcon } from '../icons';
 
 const useStyles = makeStyles(({ palette }: Theme) =>
   createStyles({

--- a/src/view/components/QueryStateIndicators/WarningIconError.tsx
+++ b/src/view/components/QueryStateIndicators/WarningIconError.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Grid, Typography } from '@material-ui/core';
-import { WarningIcon } from '../icons';
+import { Warning as WarningIcon } from '../icons';
 
 export interface WarningIconErrorProps {
   size?: 'small' | 'large';

--- a/src/view/components/icons.tsx
+++ b/src/view/components/icons.tsx
@@ -1,2 +1,9 @@
-export { Warning as WarningIcon } from '@material-ui/icons';
-export { AssignmentTurnedInOutlined as CheckIcon } from '@material-ui/icons';
+/**
+ * Used to consolidate which icon components we are using in the app
+ */
+export {
+  VerifiedUserOutlined,
+  AssignmentTurnedInOutlined,
+  Warning,
+  InfoOutlined,
+} from '@material-ui/icons';


### PR DESCRIPTION
## Proposed change/fix

Remove the usage of claimed/unclaimed icon buttons in the cert card due to spacing/formatting issues. 

I also think it is a bad user experience to have one of the icons be clickable but the other row ("is valid") not be clickable. This PR also simplifies the code a good bit.

## Types of changes

What types of changes does this pull request introduce?

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Visual change (includes a change visible to an end user)
-   [ ] Other (could be a small readme update, documentation contribution, etc.)

## Screenshots (visual updates only)

<img width="286" alt="Screen Shot 2020-11-17 at 9 30 05 AM" src="https://user-images.githubusercontent.com/20157849/99409980-90e53a00-28b7-11eb-8d65-b175a0b176e6.png">
<img width="302" alt="Screen Shot 2020-11-17 at 9 30 28 AM" src="https://user-images.githubusercontent.com/20157849/99409985-917dd080-28b7-11eb-83af-c91619b2eba3.png">

## How to run/test

Follow the instructions in the original PR.