### PR TITLE
refactor: use useeffect

### DIFF
--- a/src/view/forms/organization/CreateContact.tsx
+++ b/src/view/forms/organization/CreateContact.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { hasEmptyFields, onChangeEvent } from 'view/forms/utils';
+import React, { useEffect, useState } from 'react';
+import { hasEmptyFields } from 'view/forms/utils';
 import { IContactStrict } from 'services/protobuf/organization';
 import { Grid, TextField, Button, Typography } from '@material-ui/core';
 
 interface CreateContactFormProps {
-  onSubmit: (contact: IContactStrict) => any;
+  onSubmit?: (contact: IContactStrict) => void;
+  onChange?: (contact: IContactStrict) => void;
   submitLabel?: string;
   existingContact?: IContactStrict;
 }
@@ -14,6 +15,7 @@ interface CreateContactFormProps {
  */
 export const CreateContactForm = ({
   onSubmit,
+  onChange,
   submitLabel = 'Submit',
   existingContact,
 }: CreateContactFormProps) => {
@@ -27,16 +29,22 @@ export const CreateContactForm = ({
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
-    onSubmit(contact);
-  };
 
-  const onChange = (event: onChangeEvent, key: keyof IContactStrict) => {
-    setContact({ ...contact, [key]: event.target.value });
-
-    if (existingContact) {
-      onSubmit({ ...contact, [key]: event.target.value });
+    if (onSubmit) {
+      onSubmit(contact);
     }
   };
+
+  useEffect(() => {
+    /**
+     * The `onChange` handler for each input will keep the internal
+     * state of the form updated. If the parent also passes an `onChange`,
+     * call that function to keep the parent in sync.
+     */
+    if (onChange) {
+      onChange(contact);
+    }
+  }, [contact]);
 
   return (
     <Grid container direction="column" spacing={2}>
@@ -48,7 +56,7 @@ export const CreateContactForm = ({
           <TextField
             color="secondary"
             value={contact.name}
-            onChange={(e) => onChange(e, 'name')}
+            onChange={(e) => setContact({ ...contact, name: e.target.value })}
             label="Name"
             id="contact-name"
             variant="outlined"
@@ -59,7 +67,9 @@ export const CreateContactForm = ({
           <TextField
             color="secondary"
             value={contact.phone_number}
-            onChange={(e) => onChange(e, 'phone_number')}
+            onChange={(e) =>
+              setContact({ ...contact, phone_number: e.target.value })
+            }
             label="Phone Number"
             id="contact-phone-number"
             variant="outlined"
@@ -70,7 +80,9 @@ export const CreateContactForm = ({
           <TextField
             color="secondary"
             value={contact.language_code}
-            onChange={(e) => onChange(e, 'language_code')}
+            onChange={(e) =>
+              setContact({ ...contact, language_code: e.target.value })
+            }
             label="Language Code"
             id="contact-language-code"
             variant="outlined"
@@ -79,7 +91,7 @@ export const CreateContactForm = ({
         </Grid>
       </Grid>
 
-      {!!existingContact || (
+      {onSubmit && (
         <Grid item>
           <Button
             type="submit"

--- a/src/view/forms/organization/CreateFactoryAddress.tsx
+++ b/src/view/forms/organization/CreateFactoryAddress.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { hasEmptyFields, onChangeEvent } from 'view/forms/utils';
+import React, { useEffect, useState } from 'react';
+import { hasEmptyFields } from 'view/forms/utils';
 import { IFactoryAddressStrict } from 'services/protobuf/organization';
 import { Button, Grid, TextField, Typography } from '@material-ui/core';
 
 interface CreateFactoryAddressFormProps {
-  onSubmit: (address: IFactoryAddressStrict) => any;
+  onSubmit?: (address: IFactoryAddressStrict) => void;
+  onChange?: (contact: IFactoryAddressStrict) => void;
   submitLabel?: string;
   existingAddress?: IFactoryAddressStrict;
 }
@@ -14,6 +15,7 @@ interface CreateFactoryAddressFormProps {
  */
 export const CreateFactoryAddressForm = ({
   onSubmit,
+  onChange,
   submitLabel = 'Submit',
   existingAddress,
 }: CreateFactoryAddressFormProps) => {
@@ -30,16 +32,22 @@ export const CreateFactoryAddressForm = ({
    */
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
-    onSubmit(address);
-  };
 
-  const onChange = (event: onChangeEvent, key: keyof IFactoryAddressStrict) => {
-    setAddress({ ...address, [key]: event.target.value });
-
-    if (existingAddress) {
-      onSubmit({ ...address, [key]: event.target.value });
+    if (onSubmit) {
+      onSubmit(address);
     }
   };
+
+  useEffect(() => {
+    /**
+     * The `onChange` handler for each input will keep the internal
+     * state of the form updated. If the parent also passes an `onChange`,
+     * call that function to keep the parent in sync.
+     */
+    if (onChange) {
+      onChange(address);
+    }
+  }, [address]);
 
   return (
     <Grid container direction="column" spacing={2}>
@@ -53,7 +61,12 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.street_line_1}
-              onChange={(e) => onChange(e, 'street_line_1')}
+              onChange={(e) =>
+                setAddress({
+                  ...address,
+                  street_line_1: e.target.value,
+                })
+              }
               label="Street Line 1"
               id="street-line-1"
               variant="outlined"
@@ -65,7 +78,12 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.street_line_2}
-              onChange={(e) => onChange(e, 'street_line_2')}
+              onChange={(e) =>
+                setAddress({
+                  ...address,
+                  street_line_2: e.target.value,
+                })
+              }
               label="Street Line 2"
               id="street-line-2"
               variant="outlined"
@@ -78,7 +96,7 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.city}
-              onChange={(e) => onChange(e, 'city')}
+              onChange={(e) => setAddress({ ...address, city: e.target.value })}
               label="City"
               id="city"
               variant="outlined"
@@ -90,7 +108,9 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.postal_code || ''}
-              onChange={(e) => onChange(e, 'postal_code')}
+              onChange={(e) =>
+                setAddress({ ...address, postal_code: e.target.value })
+              }
               label="Postal Code"
               id="postal-code"
               variant="outlined"
@@ -103,7 +123,12 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.state_province || ''}
-              onChange={(e) => onChange(e, 'state_province')}
+              onChange={(e) =>
+                setAddress({
+                  ...address,
+                  state_province: e.target.value,
+                })
+              }
               label="State Province"
               id="state-province"
               variant="outlined"
@@ -114,7 +139,9 @@ export const CreateFactoryAddressForm = ({
               color="secondary"
               fullWidth
               value={address.country}
-              onChange={(e) => onChange(e, 'country')}
+              onChange={(e) =>
+                setAddress({ ...address, country: e.target.value })
+              }
               label="Country"
               id="country"
               variant="outlined"
@@ -124,7 +151,7 @@ export const CreateFactoryAddressForm = ({
         </Grid>
       </Grid>
 
-      {!!existingAddress || (
+      {onSubmit && (
         <Grid item>
           <Button
             color="secondary"

--- a/src/view/forms/organization/Organization.tsx
+++ b/src/view/forms/organization/Organization.tsx
@@ -207,14 +207,14 @@ export const UpdateOrganizationForm = ({
 
         <Grid item>
           <CreateFactoryAddressForm
-            onSubmit={(address) => setOrg({ ...org, address })}
+            onChange={(address) => setOrg({ ...org, address })}
             existingAddress={org.address}
           />
         </Grid>
 
         <Grid item>
           <CreateContactForm
-            onSubmit={(contacts) => setOrg({ ...org, contacts: [contacts] })}
+            onChange={(contacts) => setOrg({ ...org, contacts: [contacts] })}
             existingContact={org.contacts[0]}
           />
         </Grid>

--- a/src/view/forms/organization/SelectOrganizationType.tsx
+++ b/src/view/forms/organization/SelectOrganizationType.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { OrgTypeStrings } from 'services/protobuf/organization';
 import {
   FormGroup,
@@ -11,12 +11,14 @@ import {
 import { Organization } from 'services/protobuf/compiled';
 
 interface SelectOrganizationTypeProps {
-  onSubmit: (orgType: Organization.Type) => void;
+  onSubmit?: (orgType: Organization.Type) => void;
+  onChange?: (orgType: Organization.Type) => void;
   submitLabel?: string;
 }
 
 export const SelectOrganizationType = ({
   onSubmit,
+  onChange,
   submitLabel = 'Submit',
 }: SelectOrganizationTypeProps) => {
   const [selectedOrgType, setSelectedOrgType] = useState<OrgTypeStrings>(
@@ -26,12 +28,30 @@ export const SelectOrganizationType = ({
   // Remove the UNSET_TYPE from list of orgs
   const orgTypes = Object.keys(Organization.Type).slice(1) as OrgTypeStrings[];
 
-  const submit = (event: React.FormEvent) => {
-    event.preventDefault();
-    onSubmit(Organization.Type[selectedOrgType]);
+  const getOrgEnumFromString = () => {
+    return Organization.Type[selectedOrgType];
   };
 
-  const onChange = (orgType: OrgTypeStrings) => {
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (onSubmit) {
+      onSubmit(getOrgEnumFromString());
+    }
+  };
+
+  useEffect(() => {
+    /**
+     * The `onChange` handler for each input will keep the internal
+     * state of the form updated. If the parent also passes an `onChange`,
+     * call that function to keep the parent in sync.
+     */
+    if (onChange) {
+      onChange(getOrgEnumFromString());
+    }
+  }, [selectedOrgType]);
+
+  const handleChange = (orgType: OrgTypeStrings) => {
     if (orgType === selectedOrgType) {
       setSelectedOrgType('UNSET_TYPE');
     } else {
@@ -54,7 +74,7 @@ export const SelectOrganizationType = ({
                     <Checkbox
                       checked={selectedOrgType === orgType}
                       onChange={() => {
-                        onChange(orgType);
+                        handleChange(orgType);
                       }}
                       name={orgType}
                     />
@@ -66,15 +86,17 @@ export const SelectOrganizationType = ({
           </FormGroup>
         </Grid>
 
-        <Grid item>
-          <Button
-            color="secondary"
-            onClick={submit}
-            disabled={selectedOrgType === 'UNSET_TYPE'}
-          >
-            {submitLabel}
-          </Button>
-        </Grid>
+        {onSubmit && (
+          <Grid item>
+            <Button
+              color="secondary"
+              onClick={submit}
+              disabled={selectedOrgType === 'UNSET_TYPE'}
+            >
+              {submitLabel}
+            </Button>
+          </Grid>
+        )}
       </Grid>
     </form>
   );

--- a/src/view/forms/utils.tsx
+++ b/src/view/forms/utils.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { Grid, Typography, TextFieldProps } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { BatchStatusRes } from 'services/api';
 
 export interface TransactionFormProps {
   setBatchStatusLink: (statusLink: BatchStatusRes['link']) => void;
 }
-
-export type onChangeEvent = Parameters<
-  NonNullable<TextFieldProps['onChange']>
->[0];
 
 /**
  * Helper function that checks if any values in `state` have not been set.

--- a/src/view/modals/TransferFactory/Header.tsx
+++ b/src/view/modals/TransferFactory/Header.tsx
@@ -17,13 +17,7 @@ export const Header = ({ handleClose }: HeaderProps) => {
   return (
     <Grid container justify="space-between">
       {spacer}
-      <Grid
-        container
-        alignItems="center"
-        direction="column"
-        xs={10}
-        spacing={1}
-      >
+      <Grid container item alignItems="center" direction="column" xs={10}>
         <Grid item>
           <Typography variant="h3">Confirm Factory Information</Typography>
         </Grid>


### PR DESCRIPTION
## Proposed change/fix

- Fix bug where `xs` prop was being passed on a `Grid` without the required `item` prop
- Add `onChange` prop that is used in a `useEffect` hook for forms that accept an optional existing data field to pre-populate data
- Use a declarative `switch` statement for our multi-step create org form instead of implicitly basing the steps on state variables

## Types of changes

What types of changes does this pull request introduce?

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Visual change (includes a change visible to an end user)
-   [ ] Other (could be a small readme update, documentation contribution, etc.)

## Screenshots (visual updates only)

N/A

## How to run/test

- Create a factory org from the profile page
- Run tests in the parent PR
